### PR TITLE
Reset GL FBO cache and clear shadow depth

### DIFF
--- a/Illumo/Include/Illumo/Rendering/Renderer.h
+++ b/Illumo/Include/Illumo/Rendering/Renderer.h
@@ -361,6 +361,13 @@ public:
     _backend->PushToCommandQueue(cmd);
   }
 
+  void pushClearDepth()
+  {
+    RenderCommand cmd;
+    cmd.commandType = CommandType::ClearDepthBuffer;
+    _backend->PushToCommandQueue(cmd);
+  }
+
   void pushClearScreen(float r, float g, float b, float a)
   {
     RenderCommand cmd;

--- a/Illumo/Source/Rendering/OpenGL/GLDevice.cpp
+++ b/Illumo/Source/Rendering/OpenGL/GLDevice.cpp
@@ -76,6 +76,8 @@ GLDevice::ExecuteCommandQueue(CommandQueue& commandQueue,
   for (int s = 0; s < 8; ++s) {
     _boundTexture[s] = 0;
   }
+  // Not 0: first SetFramebuffer({}) must still call glBindFramebuffer(0).
+  _boundFbo = static_cast<GLuint>(-1);
   _viewportX = -1;
   _viewportY = -1;
   _viewportW = -1;

--- a/Illumo/Source/Rendering/Primitives/MeshVisual.cpp
+++ b/Illumo/Source/Rendering/Primitives/MeshVisual.cpp
@@ -684,7 +684,7 @@ MeshVisual::appendCommandsWithWorld(Renderer* value, const glm::mat4& nodeWorld)
     if (shadowFboHandle.isValid()) {
       value->pushFramebuffer(shadowFboHandle);
       value->pushViewport(0, 0, 1024, 1024);
-      value->pushClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+      value->pushClearDepth();
 
       const glm::mat4 lightMvp = lightSpaceMatrix * coloredWorld;
       value->bindStyle(shadowDepthStyleHandle);

--- a/Illumo/Tests/AGENTS.md
+++ b/Illumo/Tests/AGENTS.md
@@ -12,8 +12,8 @@ SceneGraph cases are `Illumo.SceneGraph.HandlesAndLifetime`,
 `Illumo.SceneGraph.HierarchyAndTransforms`, and
 `Illumo.SceneGraph.RenderExtraction`. MeshVisual cases are
 `Illumo.MeshVisual.DynamicMeshReuse`, `Illumo.MeshVisual.SpriteAndCube`,
-`Illumo.MeshVisual.Billboard`, `Illumo.MeshVisual.SceneAttachment`, and
-`Illumo.MeshVisual.NewPrimitives`.
+`Illumo.MeshVisual.Billboard`, `Illumo.MeshVisual.SceneAttachment`,
+`Illumo.MeshVisual.NewPrimitives`, and `Illumo.MeshVisual.ShadowDepthClear`.
 
 Use `Illumo::TestSupport` for MockBackend and test-only fixtures. Tests must be
 headless, deterministic, and isolated under `build/Testing/Illumo/`.

--- a/Illumo/Tests/TestMeshVisual.cpp
+++ b/Illumo/Tests/TestMeshVisual.cpp
@@ -424,6 +424,68 @@ testMeshVisualNewPrimitivesEmitTokens()
            "ellipse draw has 16 triangle fan indices");
 }
 
+static void
+testMeshVisualShadowDepthClear()
+{
+  testSection("MeshVisual: shadow pass clears depth, not color");
+  NullRenderWindow window(640, 480);
+  EnvVars env;
+  env.setVar("WinX", 640);
+  env.setVar("WinY", 480);
+  Camera camera(glm::vec2(0.0f, 0.0f), 1.0f, &env);
+  MockBackend mock;
+  mock.Initialize();
+  Renderer renderer(&window, &env, &camera, &mock, false);
+
+  MeshVisual visual;
+  visual.prepare(&renderer);
+  visual.setLightingEnabled(true);
+  visual.addSolidCube(
+    glm::vec3(0.0f), glm::vec3(0.5f), ColorRgba{ 200, 200, 200, 255 });
+
+  renderer.BeginFrame();
+  testTrue(g, visual.AppendCommands(&renderer), "lit cube emits tokens");
+  renderer.EndFrame();
+
+  const size_t count = mock.getLastNonEmptySubmittedCount();
+  size_t bindIndex = count;
+  size_t clearIndex = count;
+  size_t drawIndex = count;
+  size_t unbindIndex = count;
+  bool colorClearInShadow = false;
+  for (size_t i = 0; i < count; ++i) {
+    const RenderCommand& command = mock.getLastNonEmptySubmitted(i);
+    if (bindIndex == count) {
+      if (command.commandType == CommandType::SetFramebuffer &&
+          command.bindFramebuffer.handle.isValid()) {
+        bindIndex = i;
+      }
+      continue;
+    }
+    if (command.commandType == CommandType::ClearColorBuffer) {
+      colorClearInShadow = true;
+    }
+    if (clearIndex == count &&
+        command.commandType == CommandType::ClearDepthBuffer) {
+      clearIndex = i;
+    }
+    if (drawIndex == count && command.commandType == CommandType::DrawIndexed) {
+      drawIndex = i;
+    }
+    if (command.commandType == CommandType::SetFramebuffer &&
+        !command.bindFramebuffer.handle.isValid()) {
+      unbindIndex = i;
+      break;
+    }
+  }
+  testTrue(g,
+           bindIndex < clearIndex && clearIndex < drawIndex &&
+             drawIndex < unbindIndex,
+           "shadow subsequence is FBO, ClearDepthBuffer, DrawIndexed, unbind");
+  testTrue(
+    g, !colorClearInShadow, "shadow pass does not emit ClearColorBuffer");
+}
+
 void
 registerMeshVisualTests(IllumoTestRegistry& registry)
 {
@@ -439,5 +501,8 @@ registerMeshVisualTests(IllumoTestRegistry& registry)
   });
   registry.add("Illumo.MeshVisual.NewPrimitives", []() {
     return runMeshVisualCase(testMeshVisualNewPrimitivesEmitTokens);
+  });
+  registry.add("Illumo.MeshVisual.ShadowDepthClear", []() {
+    return runMeshVisualCase(testMeshVisualShadowDepthClear);
   });
 }


### PR DESCRIPTION
Closes #41 and Closes #39. Short summary:
- #41 GLDevice::ExecuteCommandQueue sets _boundFbo to an invalid sentinel (not 0) so the first SetFramebuffer({}) still binds 0
- #39 MeshVisual shadow pass uses Renderer::pushClearDepth (ClearDepthBuffer) instead of pushClearColor; TestMeshVisual asserts FBO, ClearDepthBuffer, DrawIndexed, unbind