### PR TITLE
Implement FPS limiter and frame pacing in application main loop

### DIFF
--- a/Illumo/Source/Engine/Application.cpp
+++ b/Illumo/Source/Engine/Application.cpp
@@ -5,6 +5,7 @@
 #ifndef NDEBUG
 #include <Illumo/Engine/DebugModule.h>
 #endif
+#include "Rendering/PresentationTiming.h"
 #include <Illumo/Services/EnvVars.h>
 #include <Illumo/Services/Logger.h>
 #include <chrono>
@@ -104,6 +105,12 @@ RunIllumoApplication(int argc,
       {
         ZoneScopedN("Frame.Render");
         illumo.render();
+      }
+
+      {
+        ZoneScopedN("Frame.Pacing");
+        const long targetFps = getTargetFps(&illumo.environment());
+        paceFrame(currentTime, targetFps);
       }
     }
 

--- a/Illumo/Source/Rendering/PresentationTiming.h
+++ b/Illumo/Source/Rendering/PresentationTiming.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <Illumo/Services/IEnvVars.h>
+#include <chrono>
 #include <string>
+#include <thread>
 
 inline bool
 isVsyncRequested(IEnvVars* envVars)
@@ -12,6 +14,61 @@ isVsyncRequested(IEnvVars* envVars)
 
   const EnvVar& configured = envVars->getVar("vsync");
   return configured.value.empty() ? true : configured.valueAsBool;
+}
+
+inline long
+getTargetFps(IEnvVars* envVars)
+{
+  if (envVars == nullptr) {
+    return 60;
+  }
+
+  const EnvVar& configured = envVars->getVar("fps");
+  if (configured.value.empty()) {
+    return 60;
+  }
+
+  // A value <= 0 explicitly disables the limiter (uncapped).
+  return configured.valueAsLong < 0 ? 0 : configured.valueAsLong;
+}
+
+inline std::chrono::nanoseconds
+calculateTargetFrameDuration(long targetFps)
+{
+  if (targetFps <= 0) {
+    return std::chrono::nanoseconds::zero();
+  }
+  return std::chrono::nanoseconds(1'000'000'000LL / targetFps);
+}
+
+inline void
+paceFrame(std::chrono::steady_clock::time_point frameStartTime, long targetFps)
+{
+  const std::chrono::nanoseconds targetDuration =
+    calculateTargetFrameDuration(targetFps);
+  if (targetDuration <= std::chrono::nanoseconds::zero()) {
+    return;
+  }
+
+  const std::chrono::steady_clock::time_point targetEndTime =
+    frameStartTime + targetDuration;
+  std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+
+  if (now >= targetEndTime) {
+    return;
+  }
+
+  // Sleep coarse chunk if sufficient time remains (> 2ms) to avoid high CPU
+  // usage.
+  while (targetEndTime - now > std::chrono::milliseconds(2)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    now = std::chrono::steady_clock::now();
+  }
+
+  // Spin-wait / yield for final sub-millisecond precision.
+  while (std::chrono::steady_clock::now() < targetEndTime) {
+    std::this_thread::yield();
+  }
 }
 
 inline std::string

--- a/Illumo/Tests/TestRuntimeUtilities.cpp
+++ b/Illumo/Tests/TestRuntimeUtilities.cpp
@@ -230,6 +230,39 @@ testPresentationTimingPolicy()
            buildFrameRateLabel(false, 999, 4812) ==
              "Paced FPS: off | Submit FPS: 4812",
            "uncapped label does not misreport submissions as presented FPS");
+
+  testTrue(
+    g, getTargetFps(nullptr) == 60, "missing environment defaults to 60 FPS");
+  EnvVars fpsEnv;
+  testTrue(
+    g, getTargetFps(&fpsEnv) == 60, "missing fps var defaults to 60 FPS");
+  fpsEnv.setVar("fps", 144);
+  testTrue(
+    g, getTargetFps(&fpsEnv) == 144, "positive fps var returns target FPS");
+  fpsEnv.setVar("fps", 0);
+  testTrue(g, getTargetFps(&fpsEnv) == 0, "zero fps var selects uncapped");
+  fpsEnv.setVar("fps", -10);
+  testTrue(g, getTargetFps(&fpsEnv) == 0, "negative fps var selects uncapped");
+
+  testTrue(g,
+           calculateTargetFrameDuration(0) == std::chrono::nanoseconds::zero(),
+           "zero target FPS has zero target duration");
+  testTrue(g,
+           calculateTargetFrameDuration(60) ==
+             std::chrono::nanoseconds(1'000'000'000LL / 60),
+           "60 FPS calculates correct duration");
+
+  // Verify paceFrame delays approximately the target duration
+  const auto start = std::chrono::steady_clock::now();
+  // 100 FPS = 10ms frame time
+  paceFrame(start, 100);
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  testTrue(g,
+           elapsed >= std::chrono::milliseconds(9),
+           "paceFrame waits for at least the requested duration");
+  testTrue(g,
+           elapsed < std::chrono::milliseconds(50),
+           "paceFrame does not overshoot excessively");
 }
 
 static void


### PR DESCRIPTION
Read the configured 'fps' environment variable in PresentationTiming and throttle frame execution in Application's main loop using a hybrid sleep and yield pacing strategy. Add unit test coverage for target FPS configuration, duration calculation, and frame pacing delays.